### PR TITLE
Subset CSV by columns and/or lines

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,6 +31,19 @@ column_separator in attribute need defined according filename.csv. if column sep
 \include::filename.csv[columns=1;5..8;10..15, column_separator=";"]
 ```
 
+Lines can also be extracted, along with columns.
+
+```asciidoc
+\include::filename.csv[lines=1:5, columns=1;5..8;10..15, column_separator=","]
+```
+
+
+Or just lines, in the asciidoctor standard csv processor.
+
+```asciidoc
+\include::filename.csv[lines=1:5]
+```
+
 == Example
 * Original csv file
 

--- a/README.adoc
+++ b/README.adoc
@@ -34,14 +34,14 @@ column_separator in attribute need defined according filename.csv. if column sep
 Lines can also be extracted, along with columns.
 
 ```asciidoc
-\include::filename.csv[lines=1:5, columns=1;5..8;10..15, column_separator=","]
+\include::filename.csv[lines=1;5, columns=1;5..8;10..15, column_separator=","]
 ```
 
 
 Or just lines, in the asciidoctor standard csv processor.
 
 ```asciidoc
-\include::filename.csv[lines=1:5]
+\include::filename.csv[lines=1;5]
 ```
 
 == Example

--- a/lib/csvsubcolumn-include-processor.rb
+++ b/lib/csvsubcolumn-include-processor.rb
@@ -1,5 +1,5 @@
 RUBY_ENGINE == 'opal' ? (require 'csvsubcolumn-include-processor/extension') : (require_relative 'csvsubcolumn-include-processor/extension')
 
-Extensions.register do
-  include_processor CsvSubcolumnIncludeProcessor 
+Asciidoctor::Extensions.register do
+	include_processor CsvSubcolumnIncludeProcessor
 end

--- a/lib/csvsubcolumn-include-processor/extension.rb
+++ b/lib/csvsubcolumn-include-processor/extension.rb
@@ -38,7 +38,18 @@ class CsvSubcolumnIncludeProcessor < Asciidoctor::Extensions::IncludeProcessor
 				end
 
 				row_subset = row.select.with_index { |e, i| column_numbers.include? i+1 }
-				csv_string << row_subset.join(',')
+
+				quoted_row = row_subset.map do |item|
+          if item.nil?
+            item
+          elsif item.include?(",")
+            '"' + item + '"'
+          else
+            item
+          end
+        end
+
+				csv_string << quoted_row.join(',')
 				csv_string << "\n"
 			end
 
@@ -50,7 +61,18 @@ class CsvSubcolumnIncludeProcessor < Asciidoctor::Extensions::IncludeProcessor
 			csv_string = ""
 			CSV.foreach(target, "r", col_sep: csvfile_separator).with_index(1) do |row, lineno|
 				if line_numbers.include?(lineno)
-					csv_string << row.join(',')
+
+				  quoted_row = row.map do |item|
+            if item.nil?
+              item
+            elsif item.include?(",")
+              '"' + item + '"'
+            else
+              item
+            end
+          end
+
+					csv_string << quoted_row.join(',')
 					csv_string << "\n"
 				end
 			end

--- a/lib/csvsubcolumn-include-processor/extension.rb
+++ b/lib/csvsubcolumn-include-processor/extension.rb
@@ -40,14 +40,14 @@ class CsvSubcolumnIncludeProcessor < Asciidoctor::Extensions::IncludeProcessor
 				row_subset = row.select.with_index { |e, i| column_numbers.include? i+1 }
 
 				quoted_row = row_subset.map do |item|
-          if item.nil?
-            item
-          elsif item.include?(",")
-            '"' + item + '"'
-          else
-            item
-          end
-        end
+					if item.nil?
+						item
+					elsif item.include?(",")
+						'"' + item + '"'
+					else
+						item
+					end
+				end
 
 				csv_string << quoted_row.join(',')
 				csv_string << "\n"
@@ -62,15 +62,15 @@ class CsvSubcolumnIncludeProcessor < Asciidoctor::Extensions::IncludeProcessor
 			CSV.foreach(target, "r", col_sep: csvfile_separator).with_index(1) do |row, lineno|
 				if line_numbers.include?(lineno)
 
-				  quoted_row = row.map do |item|
-            if item.nil?
-              item
-            elsif item.include?(",")
-              '"' + item + '"'
-            else
-              item
-            end
-          end
+					quoted_row = row.map do |item|
+						if item.nil?
+							item
+						elsif item.include?(",")
+							'"' + item + '"'
+						else
+							item
+						end
+					end
 
 					csv_string << quoted_row.join(',')
 					csv_string << "\n"


### PR DESCRIPTION
Thanks for the extension. I needed to subset by both columns, as your extension provides, and [line ranges](https://docs.asciidoctor.org/asciidoc/latest/directives/include-lines/). It was surprising that normal functions like `lines=1..3` didn't work out of the box when extended but I went ahead and gave it an implementation anyway. 

Never written ruby before so feel free to correct or suggest modifications. Changes are generally

1. subset csv by columns and/or lines
2. subset by lines alone
3. update readme
4. format rb files with an online formatter